### PR TITLE
fix hot reloading

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "index.html"
   ],
   "scripts": {
-    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot",
+    "dev": "cross-env NODE_ENV=development webpack-dev-server --open --hot --inline",
     "build": "cross-env NODE_ENV=production webpack --progress --hide-modules",
     "build-component": "poi build ./src/main.js --format cjs --dist standalone --filename.js SpeckleAdmin.js --filename.css SpeckleAdmin.css"
   },


### PR DESCRIPTION
Hot reload wasn't working for me, requiring to stop & restart the server at every change.

Turning on `inline` mode seems to do the trick, so added  `--inline` to dev server startup script as per [SO](https://stackoverflow.com/a/39067341)