### PR TITLE
small UI fixes

### DIFF
--- a/src/AdminInterface.vue
+++ b/src/AdminInterface.vue
@@ -23,10 +23,15 @@
       <md-app-content>
         <login-form v-if='!auth'></login-form>
         <component v-else :is='currentView'></component>
-        <md-snackbar md-position="left" :md-duration="2000" :md-active.sync="showSnackbar" md-persistent style='z-index:100000'>
+        <md-snackbar md-position="center" :md-duration="2000" :md-active.sync="showSnackbar" md-persistent style='z-index:100000'>
           <span>{{message}}</span>
           <md-button class="md-primary" @click="showSnackbar = false">Close</md-button>
         </md-snackbar>
+        <div class='spk-debug'>
+          <span class='md-caption'>
+          Connected to Speckle API server : {{server}}
+          </span>
+        </div>
       </md-app-content>
     </md-app>
   </div>
@@ -93,7 +98,7 @@ export default {
     }
   },
   mounted( ) {
-    console.log( 'Admin ui mounted!' )
+    console.log( 'Admin UI mounted!' )
     window._adminBus.$on( 'message', ( content ) => {
       this.message = content
       this.showSnackbar = true
@@ -110,7 +115,7 @@ export default {
         this.$emit( 'successLogin', this.token )
       } )
       .catch( err => {
-        window._adminBus.$emit( 'message', 'Failed to log in.' )
+        window._adminBus.$emit( 'message', 'Failed to log in.' + err.message )
       } )
   }
 }
@@ -181,11 +186,17 @@ $large-size:1920px;
 .fade-enter,
 .fade-leave-to
 /* .fade-leave-active below version 2.1.8 */
-
 {
   opacity: 0;
 }
 
+.spk-debug {
+  position:fixed;
+  width:100%;
+  background-color:#F9F9F9;
+  bottom:0;
+  padding:10px;
+}
 @import "~vue-material/dist/theme/engine"; // Import the theme engine
 @include md-register-theme("default", ( primary: md-get-palette-color(blue, A400), // The primary color of your application
 // accent: md-get-palette-color(red, A400), // The accent or secondary color

--- a/src/AdminInterface.vue
+++ b/src/AdminInterface.vue
@@ -115,7 +115,7 @@ export default {
         this.$emit( 'successLogin', this.token )
       } )
       .catch( err => {
-        window._adminBus.$emit( 'message', 'Failed to log in.' + err.message )
+        window._adminBus.$emit( 'message', 'Failed to log in : ' + err.message )
       } )
   }
 }

--- a/src/AdminInterface.vue
+++ b/src/AdminInterface.vue
@@ -4,7 +4,7 @@
       <md-app-drawer :md-active.sync="showProfile">
         <profile></profile>
       </md-app-drawer>
-      <md-app-toolbar class="md-primary md-dense" style='z-index: 10' v-if='$store.state.auth'>
+      <md-app-toolbar class="md-primary md-dense" style='z-index: 10' md-elevation="0" v-if='$store.state.auth'>
         <div class="md-toolbar-row">
           <div class="md-toolbar-section-start">
             <md-button class='md-dense md-icon-button' @click='showProfile=true'>

--- a/src/AdminInterface.vue
+++ b/src/AdminInterface.vue
@@ -4,7 +4,7 @@
       <md-app-drawer :md-active.sync="showProfile">
         <profile></profile>
       </md-app-drawer>
-      <md-app-toolbar class="md-primary md-dense" style='z-index: 10' md-elevation="0" v-if='$store.state.auth'>
+      <md-app-toolbar class="md-primary md-dense" style='z-index: 10' v-if='$store.state.auth'>
         <div class="md-toolbar-row">
           <div class="md-toolbar-section-start">
             <md-button class='md-dense md-icon-button' @click='showProfile=true'>

--- a/src/AdminInterface.vue
+++ b/src/AdminInterface.vue
@@ -14,7 +14,7 @@
           </div>
           <div class="md-toolbar-section-end">
             <a href="https://speckle.works">
-              <img src='https://speckle.works/img/logos/logo-xs.png' width="17"/>
+              <img src='https://speckle.works/img/logos/logo-bw.png' width="25"/>
               <md-tooltip md-direction="left">Speckle.Works!</md-tooltip>
               </a>
           </div>

--- a/src/components/Profile.vue
+++ b/src/components/Profile.vue
@@ -23,7 +23,7 @@
       <div class="md-layout-item md-size-30 md-caption">member since</div>
     </div>
     <div class="md-layout md-alignment-center-center spk-cell">
-      <md-button class='md-dense md-accent' @click='logout'>Logout</md-button>
+      <md-button class='md-dense md-accent' style='width:100%; min-height:60px;'@click='logout'>Logout</md-button>
     </div>
   </div>
 </template>

--- a/src/components/StreamsView.vue
+++ b/src/components/StreamsView.vue
@@ -139,29 +139,40 @@
           </div>
           <!-- extras -->
           <div class="md-layout-item md-size-20 md-text-center md-medium-hide">
-            <md-button class='md-dense md-icon-button' style='margin-top: 10px; pointer-events:all;' @click='goToViewer(item.streamId)'>
+            <span class="spk-button">
+            <md-button class='md-dense md-icon-button' @click='goToViewer(item.streamId)'>
               <md-icon>3d_rotation</md-icon>
-              <!-- <md-tooltip md-direction="bottom">View 3D data</md-tooltip> -->
             </md-button>
-            <md-button class='md-dense md-icon-button md-small-hide' style='margin-top: 10px;pointer-events:all;' @click='showHistory=true; selectedStreamId=item.streamId'>
+            <md-tooltip md-direction="bottom" class="spk-button-tooltip">Launch the Speckle 3D viewer</md-tooltip>
+          </span>
+          <span class="spk-button">
+            <md-button class='md-dense md-icon-button md-small-hide' @click='showHistory=true; selectedStreamId=item.streamId'>
               <md-icon>history</md-icon>
-              <!-- <md-tooltip md-direction="bottom">stream history</md-tooltip> -->
             </md-button>
-            <md-button class='md-dense md-icon-button md-xsmall-hide' style='margin-top: 10px;' @click='showQuery=true; selectedStreamId=item.streamId'>
+            <md-tooltip md-direction="bottom" class="spk-button-tooltip">View stream history</md-tooltip>
+          </span>
+          <span class="spk-button">
+            <md-button class='md-dense md-icon-button md-xsmall-hide' @click='showQuery=true; selectedStreamId=item.streamId'>
               <md-icon>filter_list</md-icon>
-              <!-- <md-tooltip md-direction="bottom">Query</md-tooltip> -->
             </md-button>
+            <md-tooltip md-direction="bottom" class="spk-button-tooltip">Query the stream</md-tooltip>
+          </span>
           </div>
           <!-- archive, delete -->
           <div class="md-layout-item md-size-15 md-text-right md-medium-hide">
-            <md-button class='md-accent md-icon-button md-dense' style='margin-top: 10px; pointer-events:all;' v-if='item.deleted' @click='deleteStreamConfirm=true;  selectedStreamId = item.streamId'>
+            <span class="spk-button">
+            <md-button class='md-accent md-icon-button md-dense' v-if='item.deleted' @click='deleteStreamConfirm=true;  selectedStreamId = item.streamId'>
               <md-icon>delete</md-icon>
-              <md-tooltip md-direction='bottom'>Delete this stream permanently</md-tooltip>
             </md-button>
-            <md-button :class='{ "md-dense md-icon-button" : true, "md-accent" : !item.deleted, "md-primary" : item.deleted }' style='margin-top: 10px; pointer-events:all;' @click='setStreamArchived(item)' :disabled='!(item.canWrite.indexOf($store.state.user._id) >= 0 )&&!item.isOwner'>
+            <md-tooltip class="spk-button-tooltip" md-direction='bottom'>Delete this stream permanently</md-tooltip>
+          </span>
+            <span class="spk-button">
+            <md-button :class='{ "md-dense md-icon-button" : true, "md-accent" : !item.deleted, "md-primary" : item.deleted }' @click='setStreamArchived(item)' :disabled='!(item.canWrite.indexOf($store.state.user._id) >= 0 )&&!item.isOwner'>
               <md-icon>{{item.deleted ? "unarchive" : "archive"}}</md-icon>
-              <md-tooltip md-direction="bottom">{{item.deleted ? "Unarchive stream" : "Archive stream"}}</md-tooltip>
             </md-button>
+            <md-tooltip class="spk-button-tooltip" md-direction="bottom">{{item.deleted ? "Unarchive stream" : "Archive stream"}}</md-tooltip>
+          </span>
+
           </div>
           <!-- mobile menu -->
           <div class="md-layout-item md-size-10 md-xsmall-size-25 spk-padding md-medium-show md-text-right" style='pointer-events:all'>
@@ -386,6 +397,15 @@ export default {
 
 .spk-push-down {
   margin-top: 90px;
+}
+
+.spk-button-tooltip {
+  margin-top: 20px;
+}
+
+.spk-button {
+  padding-top: 10px;
+  pointer-events:all;
 }
 
 .spk-tools {

--- a/src/components/StreamsView.vue
+++ b/src/components/StreamsView.vue
@@ -116,14 +116,20 @@
           <!-- permissions -->
           <div class="md-text-center md-layout-item md-size-5 md-medium-size-15">
             <div v-if='item.isOwner'>
-              <md-button :disabled='item.deleted' class='md-dense-xxx md-icon-button md-raisedxxx' :class='{"md-primary":item.isOwner}' style='margin-top: 10px;' @click='showPermissions=true; selectedStreamId = item.streamId'>
-                <md-icon>{{item.private ? (item.userPermissions.length == 0 ? "lock_outline": "lock_open" ) : "public" }}</md-icon>
-              </md-button>
+              <span class="spk-button">
+                <md-button :disabled='item.deleted' class='md-dense-xxx md-icon-button md-raisedxxx' :class='{"md-primary":item.isOwner}' style='margin-top: 10px;' @click='showPermissions=true; selectedStreamId = item.streamId'>
+                  <md-icon>{{item.private ? (item.userPermissions.length == 0 ? "lock_outline": "lock_open" ) : "public" }}</md-icon>
+                </md-button>
+                <md-tooltip md-direction="bottom" class="spk-button-tooltip">Modify stream permissions</md-tooltip>
+              </span>
             </div>
             <div v-else>
-              <md-button class='md-icon-button' @click='showSharedInfo=true; selectedStreamId=item.streamId'>
-                <md-icon>{{item.canWrite.indexOf($store.state.user._id) >= 0 ? "mode_edit" : "remove_red_eye" }}</md-icon>
-              </md-button>
+              <span class="spk-button">
+                <md-button class='md-icon-button' @click='showSharedInfo=true; selectedStreamId=item.streamId'>
+                  <md-icon>{{item.canWrite.indexOf($store.state.user._id) >= 0 ? "mode_edit" : "remove_red_eye" }}</md-icon>
+                </md-button>
+                <md-tooltip md-direction="bottom" class="spk-button-tooltip">Modify stream permissions</md-tooltip>
+              </span>
             </div>
           </div>
           <!-- last modified -->


### PR DESCRIPTION
Adjusted a few things in UI :

- fixed the tooltips for the table action buttons : `permissions`, `viewer`, `history`, `query`, `archive`, `delete`
- adjusted logout button
- got rid of top blue bar shadow : it was creating the illusion of 3 levels/heights
- added debug bar to tell you what the Speckle API server address is - could do with show/hide functionality added later on
- changed position of notifications to `center` - fits better with general notifications UX (win10/OSX) and doesn't clash with debug bar


preview :
![speckle ui adjustments](https://user-images.githubusercontent.com/11439624/38449324-563b1594-3a05-11e8-84be-1ea1dbbe1652.PNG)
