### PR TITLE
Adds a plugins view

### DIFF
--- a/src/components/NavDrawer.vue
+++ b/src/components/NavDrawer.vue
@@ -116,6 +116,15 @@
           <v-list-tile-sub-title class='xxx-font-weight-light caption'>Stream processing</v-list-tile-sub-title>
         </v-list-tile-content>
       </v-list-tile>
+      <v-list-tile to='/plugins'>
+        <v-list-tile-action>
+          <v-icon>extensions</v-icon>
+        </v-list-tile-action>
+        <v-list-tile-content>
+          <v-list-tile-title>Plugins</v-list-tile-title>
+          <v-list-tile-sub-title class='xxx-font-weight-light caption'>Plugins registered on this server</v-list-tile-sub-title>
+        </v-list-tile-content>
+      </v-list-tile>
       <v-divider class='ma-3'></v-divider>
     </v-list>
     <v-list v-if='$store.state.isAuth' two-line subheader>

--- a/src/components/PluginCard.vue
+++ b/src/components/PluginCard.vue
@@ -1,0 +1,43 @@
+<template>
+  <v-card>
+    <v-card-title>
+      <span class='title font-weight-light'>{{plugin.name ? plugin.name : "No Name"}}</span>
+    </v-card-title>
+    <v-divider class='mx-0 my-0'></v-divider>
+    <v-layout row wrap>
+      <v-flex xs12 class='caption' ma-2>
+        <div v-if='plugin.desc'>
+          <v-icon small>subject</v-icon> {{plugin.desc}}
+        </div>
+        <div v-if='plugin.version'>
+          <v-icon small>timeline</v-icon> {{plugin.version }}
+        </div>
+        <div v-if='plugin.author'>
+          <v-icon small>person</v-icon> {{plugin.author}}
+        </div>
+        <div v-if='plugin.homepage'>
+          <v-icon small>link</v-icon> <a :href='plugin.homepage'>{{plugin.homepage}}</a>
+        </div>
+        <div v-if='plugin.git'>
+          <v-icon small>link</v-icon> <a :href='plugin.git'>{{plugin.git}}</a>
+        </div>
+        <div v-if='plugin.contact'>
+          <v-icon small>mail</v-icon> <a :href="'mailto:'+plugin.contact">{{plugin.contact}}</a>
+        </div>
+      </v-flex>
+    </v-layout>
+    <v-card-actions>
+      <v-btn color='primary' :href='plugin.canonicalUrl'>Go to plugin</v-btn>
+    </v-card-actions>
+  </v-card>
+</template>
+
+</template>
+<script>
+export default {
+  name: 'PluginCard',
+  props: {
+    plugin: Object
+  }
+}
+</script>

--- a/src/router.js
+++ b/src/router.js
@@ -114,6 +114,12 @@ let myRouter = new Router( {
       name: 'processor overview',
       component: ( ) => import( './views/Processor.vue' ),
       meta: { requiresAuth: true },
+    },
+    {
+      path: '/plugins',
+      name: 'plugins',
+      component: ( ) => import( './views/Plugins.vue'),
+      meta: { requiresAuth: true}
     }
   ],
 } )

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -51,6 +51,8 @@ export default new Vuex.Store( {
     dark: false,
     // toggles viewer controls
     viewerControls: false,
+    // a list of plugins registered with the server
+    plugins: [ ],
 
     // processor related
     // these are the function names for each block from /src/lambda
@@ -531,6 +533,9 @@ export default new Vuex.Store( {
     SET_LEGEND( state, legend ) {
       state.legend = legend
     },
+    ADD_PLUGIN( state, plugin ) {
+      state.plugins.push( plugin )
+    }
   },
   actions: {
     // Streams
@@ -1058,6 +1063,20 @@ export default new Vuex.Store( {
             return reject( err )
           } )
       } )
+    },
+
+    getPlugins( context, payload ) {
+      Axios.get()
+        .then( res => {
+          const plugins = res.data.plugins
+          plugins.forEach( plugin => {
+            context.commit( 'ADD_PLUGIN', plugin )
+          })
+        })
+        .catch ( err => {
+          console.warn ( err )
+          return reject ( err )
+        })
     },
 
     updateLoggedInUser: ( context, payload ) => new Promise( ( resolve, reject ) => {

--- a/src/views/Plugins.vue
+++ b/src/views/Plugins.vue
@@ -1,0 +1,36 @@
+<template>
+  <v-container grid-list-xl>
+    <v-layout row wrap>
+      <v-flex xs12 py-5 class='headline font-weight-light'>
+        Plugins are web applications that interact with your Speckle Server. <br>This page is part of the SpeckleAdmin plugin!
+      </v-flex>
+      <!-- Empty state handler -->
+      <v-flex xs12 v-if='plugins.length === 0'>
+        <p class='title font-weight-light'>Hmm, we didn't find any plugins... Which is odd since this page is part of the SpeckleAdmin plugin. 🤔
+        </p>
+      </v-flex>
+      <v-flex xs12 sm6 v-for='(plugin, index) in plugins' :key='index'>
+        <plugin-card :plugin='plugin'></plugin-card>
+      </v-flex>
+    </v-layout>
+  </v-container>
+</template>
+<script>
+
+import PluginCard from '../components/PluginCard'
+
+export default {
+  name: 'Plugins',
+  components: {
+    PluginCard
+  },
+  data: ( ) => ({
+  }),
+  computed: {
+    plugins ( ) { return this.$store.state.plugins }
+  },
+  mounted() {
+    this.$store.dispatch( 'getPlugins' )
+  }
+}
+</script>


### PR DESCRIPTION
Thought we could use a way to navigate to plugins from within SpeckleAdmin.
Which leads me to another thought: could we treat some plugins as routes within SpeckleAdmin? Goal would be the ability to drop in certain plugins as modules in order to use them within the SpeckleAdmin interface... 🤔 