### PR TITLE
allow admin user to edit streams

### DIFF
--- a/src/components/DetailDescription.vue
+++ b/src/components/DetailDescription.vue
@@ -54,6 +54,7 @@ export default {
       return marked( this.resource.description, { sanitize: true } )
     },
     canEdit( ) {
+      if (this.$store.state.user.role == 'admin') return true
       return this.isOwner ? true : this.resource.canWrite.indexOf( this.$store.state.user._id ) !== -1
     },
     isOwner( ) {

--- a/src/components/StreamDetailTitle.vue
+++ b/src/components/StreamDetailTitle.vue
@@ -51,6 +51,7 @@ export default {
       return this.$store.getters.allTags
     },
     canEdit( ) {
+      if (this.$store.state.user.role == 'admin') return true
       return this.isOwner ? true : this.stream.canWrite.indexOf( this.$store.state.user._id ) !== -1
     },
     isOwner( ) {

--- a/src/components/StreamDetailUserPerms.vue
+++ b/src/components/StreamDetailUserPerms.vue
@@ -58,6 +58,7 @@ export default {
       return `${owner.name} ${owner.surname} ${owner.company ? "(" + owner.company + ")" : ''}`
     },
     canEdit( ) {
+      if (this.$store.state.user.role == 'admin') return true
       return this.isOwner ? true : this.stream.canWrite.indexOf( this.$store.state.user._id ) !== -1
     },
     isOwner( ) {

--- a/src/views/AdminStreams.vue
+++ b/src/views/AdminStreams.vue
@@ -38,7 +38,12 @@
             <td>{{ props.item.owner }}</td>
             <td>{{ props.item.private }}</td>
             <td>
-              <v-checkbox disabled hide-details class="align-center justify-left" v-model=props.item.deleted></v-checkbox>
+              <v-checkbox disabled hide-details  v-model=props.item.deleted></v-checkbox>
+            </td>
+            <td>
+              <v-btn icon flat :to='"/streams/"+props.item.streamId'>
+                <v-icon>edit</v-icon>
+              </v-btn>
             </td>
           </tr>
         </template>

--- a/src/views/Stream.vue
+++ b/src/views/Stream.vue
@@ -65,6 +65,7 @@ export default {
       return stream
     },
     canEdit( ) {
+      if (this.$store.state.user.role == 'admin') return true
       return this.isOwner ? true : this.stream.canWrite.indexOf( this.$store.state.user._id ) !== -1
     },
     isOwner( ) {

--- a/src/views/StreamOverview.vue
+++ b/src/views/StreamOverview.vue
@@ -42,6 +42,7 @@ export default {
       return stream
     },
     canEdit( ) {
+      if (this.$store.state.user.role == 'admin') return true
       return this.isOwner ? true : this.stream.canWrite.indexOf( this.$store.state.user._id ) !== -1
     },
     isOwner( ) {

--- a/src/views/StreamSharing.vue
+++ b/src/views/StreamSharing.vue
@@ -17,6 +17,7 @@ export default {
       return this.$store.state.streams.find( s => s.streamId === this.$route.params.streamId )
     },
     canEdit( ) {
+      if (this.$store.state.user.role == 'admin') return true
       return this.isOwner ? true : this.stream.canWrite.indexOf( this.$store.state.user._id ) !== -1
     },
     isOwner( ) {


### PR DESCRIPTION
Allows admin user to edit streams. Helpful for adding users to a stream that another user has created, for example. I'd like to take a look at whether some of these permissions can be passed to components as a prop from a parent component instead of re-computing `canEdit` every time, but that's for another day 