### PR TITLE
fix(viewer): fixes object isolation for numeric groups

### DIFF
--- a/src/components/ViewerObjectGroups.vue
+++ b/src/components/ViewerObjectGroups.vue
@@ -172,42 +172,49 @@ export default {
       this.loading = true
 
       let groups = { orphans: { key: 'orphans', name: 'Orphaned Objects', objects: [ ], visible: true, isolated: false } }
-      this.$store.state.objects.forEach( ( obj, index ) => {
-        let propValue = get( obj.properties, key )
-        if ( propValue ) {
-          // if we have the group already
-          if ( groups.hasOwnProperty( propValue ) ) {
-            groups[ propValue ].objects.push( obj._id )
-          } else {
-            groups[ propValue ] = {
-              key: key,
-              name: propValue,
-              objects: [ obj._id ],
-              visible: true,
-              isolated: false
+
+      if ( this.isTextProperty ) {
+
+        this.$store.state.objects.forEach( ( obj, index ) => {
+          let propValue = get( obj.properties, key )
+          if ( propValue ) {
+            // if we have the group already
+            if ( groups.hasOwnProperty( propValue ) ) {
+              groups[ propValue ].objects.push( obj._id )
+            } else {
+              groups[ propValue ] = {
+                key: key,
+                name: propValue,
+                objects: [ obj._id ],
+                visible: true,
+                isolated: false
+              }
             }
+          } else {
+            groups.orphans.objects.push( obj._id )
           }
-        } else {
-          groups.orphans.objects.push( obj._id )
-        }
-        if ( index === this.$store.state.objects.length - 1 ) {
-          this.loading = false
-        }
-      } )
+          if ( index === this.$store.state.objects.length - 1 ) {
+            this.loading = false
+          }
+        } )
+
+      }
       Object.keys( groups ).forEach( key => this.myGroups.push( groups[ key ] ) )
-      // this.myGroups = groups
     },
     filterProp( ) {
-      console.log( this.selectedRange )
       let objIds = [ ]
+
       this.$store.state.objects.forEach( ( obj, index ) => {
         let propValue = get( obj.properties, this.groupKey )
         if ( propValue )
           if ( propValue >= this.selectedRange[ 0 ] && propValue <= this.selectedRange[ 1 ] )
             objIds.push( obj._id )
+
+
         if ( index === this.$store.state.objects.length - 1 ) {
           if ( this.myGroups[ 0 ] && this.myGroups[ 0 ].visible )
             objIds = [ ...objIds, ...this.myGroups[ 0 ].objects ]
+
           window.renderer.isolateObjects( objIds )
           window.renderer.resetColors( { propagateLegend: false } )
           window.renderer.colorByProperty( { propertyName: this.groupKey, propagateLegend: false, colors: this.coolColors } )

--- a/src/renderer/SpeckleRenderer.js
+++ b/src/renderer/SpeckleRenderer.js
@@ -736,7 +736,6 @@ export default class SpeckleRenderer extends EE {
   }
   // leaves only the provided objIds visible
   isolateObjects( objIds ) {
-    console.log( 'isolating' )
     this.scene.children.forEach( obj => {
       if ( !obj.userData._id ) return
       if ( objIds.includes( obj.userData._id ) ) obj.visible = true


### PR DESCRIPTION
groups were incorrectly created for numeric properties too, resulting in weird artefacts when
filtering objects with the provided slider. this is now fixed.

thanks to Fernando for reporting! 